### PR TITLE
Fixed overriden permissions on ElasticSearch indexing

### DIFF
--- a/modules/elastic/src/main/scala/ch/epfl/bluebrain/nexus/iam/elastic/AclDocument.scala
+++ b/modules/elastic/src/main/scala/ch/epfl/bluebrain/nexus/iam/elastic/AclDocument.scala
@@ -2,22 +2,22 @@ package ch.epfl.bluebrain.nexus.iam.elastic
 
 import java.time.Instant
 
-import ch.epfl.bluebrain.nexus.commons.iam.acls.{Path, Permissions}
+import ch.epfl.bluebrain.nexus.commons.iam.acls.{Path, Permission}
 import ch.epfl.bluebrain.nexus.commons.iam.identity.Identity
 
 /**
   *
-  * @param path        the path of the permissions
-  * @param pathDepth   the depth of the path (amount of nested levels)
-  * @param identity    the identity to which the permissions apply
-  * @param permissions the permissions
-  * @param created     the optional date information of the creation time
-  * @param updated     the date information of the updated time
+  * @param path       the path of the permissions
+  * @param pathDepth  the depth of the path (amount of nested levels)
+  * @param identity   the identity to which the permissions apply
+  * @param permission the permission
+  * @param created    the optional date information of the creation time
+  * @param updated    the date information of the updated time
   **/
 final case class AclDocument(path: Path,
                              pathDepth: Int,
                              identity: Identity,
-                             permissions: Permissions,
+                             permission: Permission,
                              created: Option[Instant],
                              updated: Instant)
 
@@ -26,27 +26,27 @@ object AclDocument {
   /**
     * Construct an [[AclDocument]]
     *
-    * @param path        the path of the permissions
-    * @param identity    the identity to which the permissions apply
-    * @param permissions the permissions
-    * @param updated     the date information of the updated time
+    * @param path       the path of the permissions
+    * @param identity   the identity to which the permissions apply
+    * @param permission the permission
+    * @param updated    the date information of the updated time
     **/
-  final def apply(path: Path, identity: Identity, permissions: Permissions, updated: Instant): AclDocument =
-    AclDocument(path, path.length, identity, permissions, None, updated)
+  final def apply(path: Path, identity: Identity, permission: Permission, updated: Instant): AclDocument =
+    AclDocument(path, path.length, identity, permission, None, updated)
 
   /**
     * Construct an [[AclDocument]]
     *
-    * @param path        the path of the permissions
-    * @param identity    the identity to which the permissions apply
-    * @param permissions the permissions
-    * @param created     the date information of the created time
-    * @param updated     the date information of the updated time
+    * @param path       the path of the permissions
+    * @param identity   the identity to which the permissions apply
+    * @param permission the permission
+    * @param created    the date information of the created time
+    * @param updated    the date information of the updated time
     **/
   final def apply(path: Path,
                   identity: Identity,
-                  permissions: Permissions,
+                  permission: Permission,
                   created: Instant,
                   updated: Instant): AclDocument =
-    AclDocument(path, path.length, identity, permissions, Some(created), updated)
+    AclDocument(path, path.length, identity, permission, Some(created), updated)
 }

--- a/modules/elastic/src/main/scala/ch/epfl/bluebrain/nexus/iam/elastic/ElasticIds.scala
+++ b/modules/elastic/src/main/scala/ch/epfl/bluebrain/nexus/iam/elastic/ElasticIds.scala
@@ -3,7 +3,7 @@ package ch.epfl.bluebrain.nexus.iam.elastic
 import java.net.URLEncoder
 
 import cats.syntax.show._
-import ch.epfl.bluebrain.nexus.commons.iam.acls.Path
+import ch.epfl.bluebrain.nexus.commons.iam.acls.{Path, Permission}
 import ch.epfl.bluebrain.nexus.commons.iam.identity.Identity
 
 object ElasticIds {
@@ -19,10 +19,11 @@ object ElasticIds {
     URLEncoder.encode(s"${config.indexPrefix}_${identity.id.show}", "UTF-8").toLowerCase
 
   /**
-    * Generates the ElasticSearch Document id from the provided ''path''.
+    * Generates the ElasticSearch Document id from the provided ''path'' and ''permission''.
     *
     * @param path the path from where to generate the id
+    * @param permission the permission from where to generate the id
     */
-  private[elastic] def id(path: Path): String =
-    URLEncoder.encode(path.show, "UTF-8").toLowerCase
+  private[elastic] def id(path: Path, permission: Permission): String =
+    URLEncoder.encode(s"${path.show}_${permission.show}", "UTF-8").toLowerCase
 }

--- a/modules/elastic/src/test/scala/ch/epfl/bluebrain/nexus/iam/elastic/FilterAclsSpec.scala
+++ b/modules/elastic/src/test/scala/ch/epfl/bluebrain/nexus/iam/elastic/FilterAclsSpec.scala
@@ -38,7 +38,9 @@ class FilterAclsSpec
     with Resources
     with Inspectors
     with BeforeAndAfterAll
-    with Eventually {
+    with Eventually
+    with CancelAfterFailure
+    with Assertions {
 
   override protected def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
@@ -94,7 +96,7 @@ class FilterAclsSpec
           indexer(PermissionsAdded(path, acls, meta)).futureValue
       }
       eventually {
-        getAll.futureValue.total shouldEqual 12L
+        getAll.futureValue.total shouldEqual 15L
       }
     }
 
@@ -120,11 +122,11 @@ class FilterAclsSpec
       filter("*" / "*" / "*" / "*" / "*" / "*", parents = true, self = false).futureValue shouldEqual FullAccessControlList(
         (userIdentity, /, Permissions(Read)),
         (userIdentity, "first" / "second", Permissions(Write)),
-        (authUser, "first" / "second" / "third", Permissions(laPerm)),
         (userIdentity, "first" / "second" / "third", Permissions(Write, Own)),
+        (authUser, "first" / "second" / "third", Permissions(laPerm)),
         (authUser, "first" / "second" / "third" / "ab", Permissions(Own)),
-        (authUser, "first" / "second" / "third" / "bc" / "cd", Permissions(instPerm)),
         (userIdentity, "first" / "second" / "third" / "bc" / "cd", Permissions(pubTerm)),
+        (authUser, "first" / "second" / "third" / "bc" / "cd", Permissions(instPerm)),
         (userIdentity, "first" / "third" / "bc" / "cd", Permissions(instPerm)),
         (userIdentity, "firstother" / "second", Permissions(laPerm))
       )
@@ -132,8 +134,8 @@ class FilterAclsSpec
 
     "search on path /*/*/*/*/*" in {
       filter("*" / "*" / "*" / "*" / "*", self = false, parents = false).futureValue shouldEqual FullAccessControlList(
-        (authUser, "first" / "second" / "third" / "bc" / "cd", Permissions(instPerm)),
-        (userIdentity, "first" / "second" / "third" / "bc" / "cd", Permissions(pubTerm)))
+        (userIdentity, "first" / "second" / "third" / "bc" / "cd", Permissions(pubTerm)),
+        (authUser, "first" / "second" / "third" / "bc" / "cd", Permissions(instPerm)))
 
       filter("*" / "*" / "*" / "*" / "*", self = true, parents = false).futureValue shouldEqual FullAccessControlList(
         (userIdentity, "first" / "second" / "third" / "bc" / "cd", Permissions(pubTerm)))
@@ -150,11 +152,11 @@ class FilterAclsSpec
       filter("*" / "*" / "*" / "*" / "*", parents = true, self = false).futureValue shouldEqual FullAccessControlList(
         (userIdentity, /, Permissions(Read)),
         (userIdentity, "first" / "second", Permissions(Write)),
-        (authUser, "first" / "second" / "third", Permissions(laPerm)),
         (userIdentity, "first" / "second" / "third", Permissions(Write, Own)),
+        (authUser, "first" / "second" / "third", Permissions(laPerm)),
         (authUser, "first" / "second" / "third" / "ab", Permissions(Own)),
-        (authUser, "first" / "second" / "third" / "bc" / "cd", Permissions(instPerm)),
         (userIdentity, "first" / "second" / "third" / "bc" / "cd", Permissions(pubTerm)),
+        (authUser, "first" / "second" / "third" / "bc" / "cd", Permissions(instPerm)),
         (userIdentity, "first" / "third" / "bc" / "cd", Permissions(instPerm)),
         (userIdentity, "firstother" / "second", Permissions(laPerm))
       )
@@ -162,8 +164,8 @@ class FilterAclsSpec
 
     "search on path /*/*/*" in {
       filter("*" / "*" / "*", self = false, parents = false).futureValue shouldEqual FullAccessControlList(
-        (authUser, "first" / "second" / "third", Permissions(laPerm)),
-        (userIdentity, "first" / "second" / "third", Permissions(Write, Own))
+        (userIdentity, "first" / "second" / "third", Permissions(Write, Own)),
+          (authUser, "first" / "second" / "third", Permissions(laPerm))
       )
 
       filter("*" / "*" / "*", self = true, parents = false).futureValue shouldEqual FullAccessControlList(
@@ -179,8 +181,8 @@ class FilterAclsSpec
       filter("*" / "*" / "*", parents = true, self = false).futureValue shouldEqual FullAccessControlList(
         (userIdentity, /, Permissions(Read)),
         (userIdentity, "first" / "second", Permissions(Write)),
-        (authUser, "first" / "second" / "third", Permissions(laPerm)),
         (userIdentity, "first" / "second" / "third", Permissions(Write, Own)),
+        (authUser, "first" / "second" / "third", Permissions(laPerm)),
         (userIdentity, "firstother" / "second", Permissions(laPerm))
       )
     }
@@ -188,8 +190,8 @@ class FilterAclsSpec
     "search on path first/*/*" in {
 
       filter("first" / "*" / "*", self = false, parents = false).futureValue shouldEqual FullAccessControlList(
-        (authUser, "first" / "second" / "third", Permissions(laPerm)),
-        (userIdentity, "first" / "second" / "third", Permissions(Write, Own))
+        (userIdentity, "first" / "second" / "third", Permissions(Write, Own)),
+          (authUser, "first" / "second" / "third", Permissions(laPerm))
       )
 
       filter("first" / "*" / "*", self = true, parents = false).futureValue shouldEqual FullAccessControlList(
@@ -205,8 +207,8 @@ class FilterAclsSpec
       filter("first" / "*" / "*", parents = true, self = false).futureValue shouldEqual FullAccessControlList(
         (userIdentity, /, Permissions(Read)),
         (userIdentity, "first" / "second", Permissions(Write)),
-        (authUser, "first" / "second" / "third", Permissions(laPerm)),
-        (userIdentity, "first" / "second" / "third", Permissions(Write, Own))
+        (userIdentity, "first" / "second" / "third", Permissions(Write, Own)),
+          (authUser, "first" / "second" / "third", Permissions(laPerm))
       )
     }
 
@@ -226,8 +228,8 @@ class FilterAclsSpec
       filter("first" / "second" / "third" / "ab", parents = true, self = false).futureValue shouldEqual FullAccessControlList(
         (userIdentity, /, Permissions(Read)),
         (userIdentity, "first" / "second", Permissions(Write)),
-        (authUser, "first" / "second" / "third", Permissions(laPerm)),
         (userIdentity, "first" / "second" / "third", Permissions(Write, Own)),
+        (authUser, "first" / "second" / "third", Permissions(laPerm)),
         (authUser, "first" / "second" / "third" / "ab", Permissions(Own))
       )
 
@@ -235,8 +237,8 @@ class FilterAclsSpec
 
     "search on path /first/second/third/bc/*" in {
       filter("first" / "second" / "third" / "bc" / "*", self = false, parents = false).futureValue shouldEqual FullAccessControlList(
-        (authUser, "first" / "second" / "third" / "bc" / "cd", Permissions(instPerm)),
-        (userIdentity, "first" / "second" / "third" / "bc" / "cd", Permissions(pubTerm)))
+        (userIdentity, "first" / "second" / "third" / "bc" / "cd", Permissions(pubTerm)),
+        (authUser, "first" / "second" / "third" / "bc" / "cd", Permissions(instPerm)))
 
       filter("first" / "second" / "third" / "bc" / "*", self = true, parents = false).futureValue shouldEqual FullAccessControlList(
         (userIdentity, "first" / "second" / "third" / "bc" / "cd", Permissions(pubTerm)))
@@ -251,10 +253,10 @@ class FilterAclsSpec
       filter("first" / "second" / "third" / "bc" / "*", parents = true, self = false).futureValue shouldEqual FullAccessControlList(
         (userIdentity, /, Permissions(Read)),
         (userIdentity, "first" / "second", Permissions(Write)),
-        (authUser, "first" / "second" / "third", Permissions(laPerm)),
         (userIdentity, "first" / "second" / "third", Permissions(Write, Own)),
-        (authUser, "first" / "second" / "third" / "bc" / "cd", Permissions(instPerm)),
-        (userIdentity, "first" / "second" / "third" / "bc" / "cd", Permissions(pubTerm))
+        (authUser, "first" / "second" / "third", Permissions(laPerm)),
+        (userIdentity, "first" / "second" / "third" / "bc" / "cd", Permissions(pubTerm)),
+        (authUser, "first" / "second" / "third" / "bc" / "cd", Permissions(instPerm))
       )
     }
 
@@ -267,8 +269,8 @@ class FilterAclsSpec
     "search on path /*/second/third" in {
 
       filter("*" / "second" / "third", self = false, parents = false).futureValue shouldEqual FullAccessControlList(
-        (authUser, "first" / "second" / "third", Permissions(laPerm)),
-        (userIdentity, "first" / "second" / "third", Permissions(Write, Own))
+        (userIdentity, "first" / "second" / "third", Permissions(Write, Own)),
+        (authUser, "first" / "second" / "third", Permissions(laPerm))
       )
       filter("*" / "second" / "third", self = true, parents = false).futureValue shouldEqual FullAccessControlList(
         (userIdentity, "first" / "second" / "third", Permissions(Write, Own)))
@@ -283,8 +285,8 @@ class FilterAclsSpec
       filter("*" / "second" / "third", self = false, parents = true).futureValue shouldEqual FullAccessControlList(
         (userIdentity, /, Permissions(Read)),
         (userIdentity, "first" / "second", Permissions(Write)),
-        (authUser, "first" / "second" / "third", Permissions(laPerm)),
         (userIdentity, "first" / "second" / "third", Permissions(Write, Own)),
+        (authUser, "first" / "second" / "third", Permissions(laPerm)),
         (userIdentity, "firstother" / "second", Permissions(laPerm))
       )
     }


### PR DESCRIPTION
The indexed documents data model have changed. Now we have a document
for each permission.

Fixes #100