### PR TITLE
Fixed ddata based indexing serialization preventing clustering

### DIFF
--- a/src/main/resources/akka.conf
+++ b/src/main/resources/akka.conf
@@ -61,6 +61,9 @@ akka {
       "ch.epfl.bluebrain.nexus.iam.realms.RealmCommand"   = kryo
       "ch.epfl.bluebrain.nexus.iam.realms.RealmRejection" = kryo
 
+      "ch.epfl.bluebrain.nexus.iam.types.Label"     = kryo
+      "ch.epfl.bluebrain.nexus.iam.types.ResourceF" = kryo
+
       "ch.epfl.bluebrain.nexus.sourcing.akka.Msg"                              = kryo
       "ch.epfl.bluebrain.nexus.service.indexer.stream.StreamCoordinator$Stop$" = kryo
       "ch.epfl.bluebrain.nexus.service.indexer.stream.StreamCoordinator$Start" = kryo


### PR DESCRIPTION
The types `Label` and `ResourceF` were not listed in the serialization bindings. With java serialization disabled in a cluster setup the distributed data based implementation of the KeyValueStore would fail to ship updates across nodes for changes to mappings `Label -> ResourceF[_]`.