### PR TITLE
Fix Permission regex

### DIFF
--- a/client/src/main/scala/ch/epfl/bluebrain/nexus/iam/client/types/Permission.scala
+++ b/client/src/main/scala/ch/epfl/bluebrain/nexus/iam/client/types/Permission.scala
@@ -4,22 +4,26 @@ import cats.Show
 import io.circe._
 
 /**
-  * Wraps a permission string.
+  * Wraps a permission string that must begin with a letter, followed by at most 31
+  * alphanumeric characters or symbols among '-', '_', ':', '\' and '/'.
   *
   * @param value a valid permission string
   */
 final case class Permission private (value: String)
 
 object Permission {
-  private val valid = "[a-zA-Z-:_\\/]{1,32}".r
+
+  private val valid = """[a-zA-Z][\w-:\\/]{0,31}""".r
 
   /**
     * Attempts to construct a [[Permission]] that passes the ''regex''
     *
     * @param value the permission value
     */
-  final def apply(value: String): Option[Permission] =
-    valid.findFirstIn(value).map(unsafe)
+  final def apply(value: String): Option[Permission] = value match {
+    case valid() => Some(unsafe(value))
+    case _       => None
+  }
 
   /**
     * Constructs a [[Permission]] without validating it against the ''regex''

--- a/src/main/scala/ch/epfl/bluebrain/nexus/iam/types/Permission.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/iam/types/Permission.scala
@@ -4,22 +4,26 @@ import cats.Show
 import io.circe._
 
 /**
-  * Wraps a permission string, e.g. ''own'', ''read'', ''write''.
+  * Wraps a permission string that must begin with a letter, followed by at most 31
+  * alphanumeric characters or symbols among '-', '_', ':', '\' and '/'.
   *
   * @param value a valid permission string
   */
 final case class Permission private (value: String)
 
 object Permission {
-  private val valid = "^[a-zA-Z-:_\\/]{1,32}$".r
+
+  private val valid = """[a-zA-Z][\w-:\\/]{0,31}""".r
 
   /**
     * Attempts to construct a [[Permission]] that passes the ''regex''
     *
     * @param value the permission value
     */
-  final def apply(value: String): Option[Permission] =
-    valid.findFirstIn(value).map(unsafe)
+  final def apply(value: String): Option[Permission] = value match {
+    case valid() => Some(unsafe(value))
+    case _       => None
+  }
 
   /**
     * Constructs a [[Permission]] without validating it against the ''regex''

--- a/src/test/scala/ch/epfl/bluebrain/nexus/iam/types/PermissionSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/iam/types/PermissionSpec.scala
@@ -1,0 +1,37 @@
+package ch.epfl.bluebrain.nexus.iam.types
+
+import ch.epfl.bluebrain.nexus.commons.test.Randomness
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.util.Random
+
+class PermissionSpec extends WordSpec with Matchers with Randomness {
+  "A Permission" should {
+    "be constructed correctly for valid strings" in {
+      for (_ <- 1 to 100) {
+        val valid = genValid
+        Permission(valid) shouldEqual Some(Permission.unsafe(valid))
+      }
+    }
+
+    "fail to construct for illegal strings" in {
+      Permission("") shouldEqual None
+      Permission("1") shouldEqual None
+      Permission("1abd") shouldEqual None
+      Permission("_abd") shouldEqual None
+      Permission("foö") shouldEqual None
+      Permission("bar*") shouldEqual None
+      Permission(genString(33)) shouldEqual None
+    }
+  }
+
+  private def genValid: String = {
+    val lower   = 'a' to 'z'
+    val upper   = 'A' to 'Z'
+    val numbers = '0' to '9'
+    val symbols = List('-', '_', ':', '\\', '/')
+    val head    = genString(1, lower ++ upper)
+    val tail    = genString(Random.nextInt(32), lower ++ upper ++ numbers ++ symbols)
+    head + tail
+  }
+}


### PR DESCRIPTION
* Fix regex escaping (we need triple quotes **and** escaping for the backslash)
* Restrict the first char to letters
* Allow numbers in the rest so that we can have `s3/read` for instance
* Perform an exact match on the entire string (the `findFirstIn` method returns partial matches)