### PR TITLE
Changed default cassandra consistency delay to a higher value

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ scalafmt: {
 
 // Dependency versions
 val alpakkaVersion             = "1.0.2"
-val commonsVersion             = "0.12.9"
+val commonsVersion             = "0.12.10"
 val sourcingVersion            = "0.16.3"
 val akkaVersion                = "2.5.23"
 val akkaCorsVersion            = "0.4.0"
@@ -37,7 +37,7 @@ val catsVersion                = "1.6.1"
 val circeVersion               = "0.11.1"
 val journalVersion             = "3.0.19"
 val logbackVersion             = "1.2.3"
-val mockitoVersion             = "1.5.6"
+val mockitoVersion             = "1.5.7"
 val monixVersion               = "3.0.0-RC2"
 val nimbusJoseJwtVersion       = "7.2.1"
 val pureconfigVersion          = "0.11.0"

--- a/src/main/resources/cassandra.conf
+++ b/src/main/resources/cassandra.conf
@@ -70,7 +70,8 @@ cassandra-query-journal {
   first-time-bucket = ${?CASSANDRA_FIRST_TIME_BUCKET}
 
   events-by-tag {
-    eventual-consistency-delay = 0s
+    # This delay helps to order events. Setting this to anything lower than 2s is highly discouraged.
+    eventual-consistency-delay = 4s
     eventual-consistency-delay = ${?CASSANDRA_EVENTUAL_CONSISTENCY_DELAY}
   }
 }


### PR DESCRIPTION
I saw this message in the logs
```
2019-06-07 09:32:13 INFO  a.p.c.q.s.CassandraReadJournal - EventsByTag eventual consistency set below 2 seconds. This can result in missed events. See reference.conf for details.
```
As stated in the [reference.conf](https://github.com/akka/akka-persistence-cassandra/blob/master/core/src/main/resources/reference.conf#L720) this value helps to order event, and anything lower than 2s is discouraged.